### PR TITLE
Add external search structures and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ from views.welcome import WelcomeContent
 from views.lineal import LinealContent
 from views.binaria import BinariaContent
 from views.hash_view import HashContent
+from views.external_sequential import ExternalSequentialContent
+from views.external_binary import ExternalBinaryContent
 
 
 class App(ctk.CTk):
@@ -50,6 +52,8 @@ class App(ctk.CTk):
             "internas:lineal": LinealContent(self.content_container),
             "internas:binaria": BinariaContent(self.content_container),
             "internas:hash": HashContent(self.content_container),
+            "externas:secuencial": ExternalSequentialContent(self.content_container),
+            "externas:binaria": ExternalBinaryContent(self.content_container),
         }
 
         self.show_content("welcome")

--- a/models/external.py
+++ b/models/external.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import bisect
+import json
+import math
+import random
+from typing import Any, Dict, List, Optional
+
+
+def _is_power_of_10(n: int) -> bool:
+    if n <= 0:
+        return False
+    while n % 10 == 0:
+        n //= 10
+    return n == 1
+
+
+@dataclass
+class SearchResult:
+    index: int
+    block: int
+    offset: int
+    found: bool
+
+    @classmethod
+    def not_found(cls, block: int = -1) -> "SearchResult":
+        return cls(-1, block, -1, False)
+
+
+@dataclass
+class ExternalStructureBase:
+    capacity: int
+    key_length: int
+    items: List[int] = field(default_factory=list)
+    type_name: str = "externa"
+
+    def __post_init__(self):
+        if not isinstance(self.capacity, int) or self.capacity <= 0:
+            raise ValueError("Capacidad inválida")
+        if self.capacity > 10000 or not _is_power_of_10(self.capacity):
+            raise ValueError("La capacidad debe ser potencia de 10 y ≤ 10000")
+        if not (1 <= int(self.key_length) <= 9):
+            raise ValueError("Longitud de clave inválida (1-9)")
+        # Normalizar datos iniciales
+        cleaned: List[int] = []
+        seen = set()
+        for value in sorted(self.items):
+            if not isinstance(value, int):
+                raise ValueError("Los datos deben ser enteros")
+            if len(str(abs(value))) != int(self.key_length):
+                raise ValueError("Clave con longitud no compatible")
+            if value in seen:
+                raise ValueError("Claves duplicadas no permitidas")
+            cleaned.append(value)
+            seen.add(value)
+        if len(cleaned) > self.capacity:
+            raise ValueError("'datos' excede la capacidad")
+        self.items = cleaned
+
+    # Propiedades de bloques
+    @property
+    def block_size(self) -> int:
+        return max(1, math.isqrt(self.capacity))
+
+    @property
+    def block_count(self) -> int:
+        size = self.block_size
+        return (self.capacity + size - 1) // size
+
+    # Utilidades internas
+    def _valid_key(self, value: int) -> bool:
+        return isinstance(value, int) and len(str(abs(value))) == int(self.key_length)
+
+    def locate_index(self, index: int) -> tuple[int, int]:
+        if index < 0 or index >= len(self.items):
+            raise ValueError("Índice fuera de rango")
+        block = index // self.block_size
+        offset = index % self.block_size
+        return block, offset
+
+    def get_blocks(self, fill: bool = True) -> List[List[Optional[int]]]:
+        blocks: List[List[Optional[int]]] = []
+        size = self.block_size
+        for b in range(self.block_count):
+            start = b * size
+            end = min(start + size, len(self.items))
+            if start >= len(self.items):
+                block: List[Optional[int]] = []
+            else:
+                block = list(self.items[start:end])
+            if fill and len(block) < size:
+                block.extend([None] * (size - len(block)))
+            blocks.append(block)
+        return blocks
+
+    def get_block_base(self, block_index: int) -> Optional[int]:
+        size = self.block_size
+        start = block_index * size
+        end = min(start + size, len(self.items))
+        if start >= len(self.items) or end == 0:
+            return None
+        return self.items[end - 1]
+
+    def get_block_bases(self) -> List[Optional[int]]:
+        return [self.get_block_base(i) for i in range(self.block_count)]
+
+    # Operaciones básicas comunes
+    @property
+    def is_full(self) -> bool:
+        return len(self.items) >= self.capacity
+
+    def insert(self, value: int) -> int:
+        if self.is_full:
+            raise ValueError("La estructura está llena")
+        if not self._valid_key(value):
+            raise ValueError("La clave no cumple la longitud configurada")
+        idx = bisect.bisect_left(self.items, value)
+        if idx < len(self.items) and self.items[idx] == value:
+            raise ValueError("La clave ya existe (duplicada)")
+        self.items.insert(idx, value)
+        return idx
+
+    def delete(self, value: int) -> int:
+        idx = bisect.bisect_left(self.items, value)
+        if idx == len(self.items) or self.items[idx] != value:
+            raise ValueError("La clave no existe")
+        self.items.pop(idx)
+        return idx
+
+    # Serialización
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tipo": self.type_name,
+            "capacidad": self.capacity,
+            "longitud_clave": int(self.key_length),
+            "datos": list(self.items),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ExternalStructureBase":
+        if not isinstance(data, dict) or data.get("tipo") != cls.type_name:
+            raise ValueError(f"Archivo incompatible: 'tipo' debe ser '{cls.type_name}'")
+        capacidad = data.get("capacidad")
+        klen = data.get("longitud_clave")
+        datos = data.get("datos")
+        if not isinstance(capacidad, int) or capacidad <= 0:
+            raise ValueError("Capacidad inválida en archivo")
+        if capacidad > 10000 or not _is_power_of_10(capacidad):
+            raise ValueError("Capacidad debe ser potencia de 10 y ≤ 10000")
+        if not isinstance(klen, int) or not (1 <= klen <= 9):
+            raise ValueError("Longitud de clave inválida en archivo")
+        if not isinstance(datos, list):
+            raise ValueError("Estructura de datos inválida en archivo")
+        for value in datos:
+            if not isinstance(value, int):
+                raise ValueError("Los datos deben ser enteros")
+            if len(str(abs(value))) != klen:
+                raise ValueError("Clave con longitud no compatible")
+        return cls(capacidad, klen, list(datos))
+
+    def generate_random(self, count: int) -> int:
+        if count <= 0:
+            return 0
+        remaining_capacity = self.capacity - len(self.items)
+        if remaining_capacity <= 0:
+            return 0
+        to_add = min(count, remaining_capacity)
+        k = int(self.key_length)
+        min_val = 0 if k == 1 else 10 ** (k - 1)
+        max_val = 10 ** k - 1
+        existing = set(self.items)
+        added_vals: List[int] = []
+        while len(added_vals) < to_add:
+            v = random.randint(min_val, max_val)
+            if v in existing:
+                continue
+            existing.add(v)
+            added_vals.append(v)
+        self.items.extend(added_vals)
+        self.items.sort()
+        return len(added_vals)
+
+    # Métodos de búsqueda (a implementar en subclases)
+    def find(self, value: int) -> SearchResult:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class ExternalSequentialStructure(ExternalStructureBase):
+    type_name = "externa_secuencial"
+
+    def _find_block_sequential(self, value: int) -> Optional[int]:
+        bases = self.get_block_bases()
+        last_valid_block = -1
+        for i, base in enumerate(bases):
+            if base is None:
+                break
+            last_valid_block = i
+            if value <= base:
+                return i
+        if last_valid_block != -1:
+            return last_valid_block
+        return None
+
+    def find(self, value: int) -> SearchResult:
+        if not self._valid_key(value):
+            return SearchResult.not_found()
+        block = self._find_block_sequential(value)
+        if block is None:
+            return SearchResult.not_found()
+        size = self.block_size
+        start = block * size
+        end = min(start + size, len(self.items))
+        for offset, idx in enumerate(range(start, end)):
+            if self.items[idx] == value:
+                return SearchResult(idx, block, offset, True)
+        return SearchResult.not_found(block)
+
+
+class ExternalBinaryStructure(ExternalStructureBase):
+    type_name = "externa_binaria"
+
+    def _find_block_binary(self, value: int) -> Optional[int]:
+        bases = []
+        indices = []
+        for i, base in enumerate(self.get_block_bases()):
+            if base is None:
+                break
+            bases.append(base)
+            indices.append(i)
+        if not bases:
+            return None
+        pos = bisect.bisect_left(bases, value)
+        if pos >= len(indices):
+            return None
+        return indices[pos]
+
+    def find(self, value: int) -> SearchResult:
+        if not self._valid_key(value):
+            return SearchResult.not_found()
+        block = self._find_block_binary(value)
+        if block is None:
+            return SearchResult.not_found()
+        size = self.block_size
+        start = block * size
+        end = min(start + size, len(self.items))
+        block_slice = self.items[start:end]
+        pos = bisect.bisect_left(block_slice, value)
+        if pos < len(block_slice) and block_slice[pos] == value:
+            return SearchResult(start + pos, block, pos, True)
+        return SearchResult.not_found(block)

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -98,9 +98,30 @@ class CollapsibleSidebar(ctk.CTkFrame):
         self.panel_externas = ctk.CTkFrame(self.sections_container, fg_color="transparent")
         self.panel_externas.grid(row=3, column=0, sticky="ew", padx=8, pady=(0, 8))
         self.panel_externas.columnconfigure(0, weight=1)
-        ctk.CTkLabel(self.panel_externas, text="Próximamente…").grid(
-            row=0, column=0, sticky="ew", padx=8, pady=8
+
+        self.btn_ext_seq = ctk.CTkButton(
+            self.panel_externas,
+            text="Secuencial",
+            height=34,
+            fg_color="transparent",
+            hover_color=("#e5f0ff", "#16324a"),
+            corner_radius=8,
+            anchor="w",
+            command=lambda: self.on_select("externas", "secuencial"),
         )
+        self.btn_ext_seq.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 4))
+
+        self.btn_ext_bin = ctk.CTkButton(
+            self.panel_externas,
+            text="Binaria",
+            height=34,
+            fg_color="transparent",
+            hover_color=("#e5f0ff", "#16324a"),
+            corner_radius=8,
+            anchor="w",
+            command=lambda: self.on_select("externas", "binaria"),
+        )
+        self.btn_ext_bin.grid(row=1, column=0, sticky="ew", padx=8, pady=(4, 8))
 
         # Grafos
         self.btn_grafos = ctk.CTkButton(
@@ -127,6 +148,8 @@ class CollapsibleSidebar(ctk.CTkFrame):
             "internas:lineal": self.btn_lineal,
             "internas:binaria": self.btn_binaria,
             "internas:hash": self.btn_hash,
+            "externas:secuencial": self.btn_ext_seq,
+            "externas:binaria": self.btn_ext_bin,
         }
 
     def toggle(self):

--- a/views/external_base.py
+++ b/views/external_base.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+import tkinter.filedialog as fd
+import tkinter.messagebox as mb
+from typing import Dict, Optional, Tuple, Type, TypeVar
+
+import customtkinter as ctk
+
+from .base import BaseContent
+from models.external import ExternalStructureBase
+
+
+StructureT = TypeVar("StructureT", bound=ExternalStructureBase)
+
+
+@dataclass
+class HighlightState:
+    block: int
+    offset: Optional[int]
+    found: bool = False
+    highlight_base: bool = False
+
+
+class ExternalBaseContent(BaseContent):
+    title = ""
+    structure_cls: Type[StructureT] = ExternalStructureBase  # type: ignore[assignment]
+    search_button_text = "Buscar"
+    search_kind_label = "externa"
+
+    def __init__(self, master):
+        super().__init__(master)
+
+        self.structure: Optional[StructureT] = None
+        self.var_exp = ctk.StringVar(value="3")
+        self.var_klen = ctk.StringVar(value="4")
+        self.var_key = ctk.StringVar()
+        self.var_gen_count = ctk.StringVar(value="100")
+
+        self.current_highlight: Optional[HighlightState] = None
+
+        # Layout principal
+        self.body.grid_columnconfigure(0, weight=1)
+        for r in range(7):
+            self.body.grid_rowconfigure(r, weight=0)
+        self.body.grid_rowconfigure(6, weight=1)
+
+        # Configuración
+        cfg_frame = ctk.CTkFrame(self.body)
+        cfg_frame.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 4))
+        cfg_frame.grid_columnconfigure(6, weight=1)
+
+        ctk.CTkLabel(cfg_frame, text="Tamaño (10^n):").grid(row=0, column=0, padx=(8, 6), pady=8, sticky="w")
+        self.exp_menu = ctk.CTkOptionMenu(cfg_frame, values=["1", "2", "3", "4"], variable=self.var_exp)
+        self.exp_menu.grid(row=0, column=1, padx=(0, 8), pady=8)
+
+        ctk.CTkLabel(cfg_frame, text="Longitud de clave:").grid(row=0, column=2, padx=(8, 6), pady=8, sticky="w")
+        self.klen_menu = ctk.CTkOptionMenu(cfg_frame, values=[str(i) for i in range(1, 10)], variable=self.var_klen)
+        self.klen_menu.grid(row=0, column=3, padx=(0, 8), pady=8)
+
+        self.btn_crear = ctk.CTkButton(cfg_frame, text="Crear", command=self.on_crear)
+        self.btn_crear.grid(row=0, column=4, padx=(0, 8), pady=8)
+
+        self.btn_borrar = ctk.CTkButton(cfg_frame, text="Borrar estructura", command=self.on_borrar, state="disabled")
+        self.btn_borrar.grid(row=0, column=5, padx=(0, 8), pady=8)
+
+        self.lbl_capacidad = ctk.CTkLabel(cfg_frame, text="Capacidad: — | Ocupados: 0 | Bloques: — | Reg/bloque: —")
+        self.lbl_capacidad.grid(row=0, column=6, padx=(8, 8), pady=8, sticky="w")
+
+        # Operaciones
+        ops_frame = ctk.CTkFrame(self.body)
+        ops_frame.grid(row=1, column=0, sticky="ew", padx=8, pady=4)
+        ops_frame.grid_columnconfigure(6, weight=1)
+
+        ctk.CTkLabel(ops_frame, text="Clave:").grid(row=0, column=0, padx=(8, 6), pady=8, sticky="w")
+        self.entry_key = ctk.CTkEntry(ops_frame, textvariable=self.var_key, width=160)
+        self.entry_key.grid(row=0, column=1, padx=(0, 8), pady=8)
+
+        self.btn_insert = ctk.CTkButton(ops_frame, text="Insertar", command=self.on_insertar, state="disabled")
+        self.btn_insert.grid(row=0, column=2, padx=(0, 6), pady=8)
+
+        self.btn_buscar = ctk.CTkButton(ops_frame, text=self.search_button_text, command=self.on_buscar, state="disabled")
+        self.btn_buscar.grid(row=0, column=3, padx=(0, 6), pady=8)
+
+        self.btn_eliminar = ctk.CTkButton(ops_frame, text="Eliminar", command=self.on_eliminar, state="disabled")
+        self.btn_eliminar.grid(row=0, column=4, padx=(0, 6), pady=8, sticky="w")
+
+        # Generación aleatoria
+        gen_frame = ctk.CTkFrame(self.body)
+        gen_frame.grid(row=2, column=0, sticky="ew", padx=8, pady=4)
+        gen_frame.grid_columnconfigure(4, weight=1)
+
+        ctk.CTkLabel(gen_frame, text="Generar aleatorios:").grid(row=0, column=0, padx=(8, 6), pady=8, sticky="w")
+        self.entry_gen = ctk.CTkEntry(gen_frame, textvariable=self.var_gen_count, width=100)
+        self.entry_gen.grid(row=0, column=1, padx=(0, 8), pady=8)
+
+        self.btn_generar = ctk.CTkButton(gen_frame, text="Generar", command=self.on_generar, state="disabled")
+        self.btn_generar.grid(row=0, column=2, padx=(0, 8), pady=8)
+
+        # Guardar / cargar
+        io_frame = ctk.CTkFrame(self.body)
+        io_frame.grid(row=3, column=0, sticky="ew", padx=8, pady=4)
+        io_frame.grid_columnconfigure(2, weight=1)
+
+        self.btn_guardar = ctk.CTkButton(io_frame, text="Guardar estructura", command=self.on_guardar, state="disabled")
+        self.btn_guardar.grid(row=0, column=0, padx=8, pady=8)
+
+        self.btn_cargar = ctk.CTkButton(io_frame, text="Cargar estructura", command=self.on_cargar)
+        self.btn_cargar.grid(row=0, column=1, padx=8, pady=8)
+
+        # Estado
+        self.lbl_estado = ctk.CTkLabel(self.body, text="Listo.")
+        self.lbl_estado.grid(row=4, column=0, sticky="ew", padx=16, pady=(4, 0))
+
+        # Visor de bloques
+        viewer_frame = ctk.CTkFrame(self.body)
+        viewer_frame.grid(row=6, column=0, sticky="nsew", padx=8, pady=(8, 12))
+        viewer_frame.grid_rowconfigure(0, weight=0)
+        viewer_frame.grid_rowconfigure(1, weight=1)
+        viewer_frame.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(viewer_frame, text="Bloques (ordenados)").grid(row=0, column=0, sticky="w", padx=8, pady=(8, 0))
+        self.blocks_container = ctk.CTkFrame(viewer_frame)
+        self.blocks_container.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
+        self.blocks_container.grid_columnconfigure(0, weight=0)
+        self.blocks_container.grid_rowconfigure(0, weight=0)
+
+        self._refresh_view()
+
+    # Helpers UI
+    def _set_controls_enabled(self, enabled: bool):
+        base = "normal" if enabled else "disabled"
+        self.btn_insert.configure(state=base)
+        self.btn_buscar.configure(state=base)
+        self.btn_eliminar.configure(state=base)
+        self.btn_guardar.configure(state=base)
+        self.btn_generar.configure(state=base)
+
+    def _set_config_enabled(self, enabled: bool):
+        state = "normal" if enabled else "disabled"
+        self.exp_menu.configure(state=state)
+        self.klen_menu.configure(state=state)
+        self.btn_crear.configure(state=state)
+        self.btn_borrar.configure(state="normal" if not enabled else "disabled")
+
+    def _update_counters(self):
+        if not self.structure:
+            text = "Capacidad: — | Ocupados: 0 | Bloques: — | Reg/bloque: —"
+        else:
+            cap = self.structure.capacity
+            occ = len(self.structure.items)
+            blocks = self.structure.block_count
+            size = self.structure.block_size
+            text = f"Capacidad: {cap} | Ocupados: {occ} | Bloques: {blocks} | Reg/bloque: {size}"
+        self.lbl_capacidad.configure(text=text)
+
+    def _refresh_view(self, highlight: Optional[HighlightState] = None):
+        for widget in self.blocks_container.winfo_children():
+            widget.destroy()
+        self.current_highlight = highlight
+
+        if not self.structure:
+            ctk.CTkLabel(
+                self.blocks_container,
+                text="Crea o carga la estructura para visualizar los bloques.",
+                anchor="w",
+                justify="left",
+            ).grid(row=0, column=0, sticky="w", padx=8, pady=8)
+            return
+
+        blocks = self.structure.get_blocks(fill=True)
+        bases = self.structure.get_block_bases()
+        block_count = len(blocks)
+        block_size = self.structure.block_size
+
+        # Encabezados de filas
+        header_font = ctk.CTkFont(weight="bold")
+        self.blocks_container.grid_columnconfigure(0, weight=0)
+        ctk.CTkLabel(self.blocks_container, text="", font=header_font, width=60).grid(
+            row=0, column=0, padx=4, pady=(0, 4)
+        )
+        ctk.CTkLabel(self.blocks_container, text="Base", font=header_font).grid(
+            row=1, column=0, padx=4, pady=2, sticky="e"
+        )
+        for r in range(block_size):
+            ctk.CTkLabel(self.blocks_container, text=f"R{r + 1}").grid(
+                row=r + 2, column=0, padx=4, pady=2, sticky="e"
+            )
+
+        # Columnas por bloque
+        for col in range(block_count):
+            self.blocks_container.grid_columnconfigure(col + 1, weight=1)
+            block_highlight = bool(highlight and highlight.block == col)
+            base_fg = self._highlight_color(
+                block_highlight and highlight.highlight_base if highlight else False,
+                highlight,
+            )
+
+            header = ctk.CTkLabel(self.blocks_container, text=f"B{col + 1}", font=header_font)
+            header.grid(row=0, column=col + 1, padx=4, pady=(0, 4))
+
+            base_val = bases[col]
+            base_text = self._format_value(base_val)
+            base_label = ctk.CTkLabel(
+                self.blocks_container,
+                text=base_text,
+                fg_color=base_fg,
+                corner_radius=6,
+                text_color="black" if base_fg else None,
+            )
+            base_label.grid(row=1, column=col + 1, padx=2, pady=2, sticky="nsew")
+
+            for r, value in enumerate(blocks[col]):
+                fg = None
+                text_color = None
+                if block_highlight and highlight and highlight.offset == r:
+                    fg = self._highlight_color(True, highlight)
+                    text_color = "black"
+                cell = ctk.CTkLabel(
+                    self.blocks_container,
+                    text=self._format_value(value),
+                    fg_color=fg,
+                    corner_radius=6,
+                    text_color=text_color,
+                )
+                cell.grid(row=r + 2, column=col + 1, padx=2, pady=2, sticky="nsew")
+
+    def _highlight_color(self, active: bool, highlight: Optional[HighlightState]) -> Optional[str]:
+        if not active:
+            return None
+        if highlight and highlight.found:
+            return "#86efac"
+        return "#fde68a"
+
+    def _format_value(self, value: Optional[int]) -> str:
+        if value is None:
+            return "—"
+        if self.structure:
+            width = int(self.structure.key_length)
+            return f"{value:0{width}d}"
+        return str(value)
+
+    def _set_estado(self, msg: str):
+        self.lbl_estado.configure(text=msg)
+
+    def _error(self, msg: str):
+        self._set_estado(msg)
+        try:
+            mb.showerror("Error", msg)
+        except Exception:
+            pass
+
+    def _parse_key(self) -> Tuple[bool, Optional[int], Optional[str]]:
+        if not self.structure:
+            return False, None, "Primero crea o carga la estructura."
+        s = (self.var_key.get() or "").strip()
+        if not s:
+            return False, None, "Ingresa una clave numérica."
+        if not s.isdigit():
+            return False, None, "La clave debe ser numérica (solo dígitos)."
+        try:
+            val = int(s)
+        except ValueError:
+            return False, None, "Clave inválida."
+        if len(str(abs(val))) != int(self.structure.key_length):
+            return False, None, f"La clave debe tener {self.structure.key_length} dígitos."
+        return True, val, None
+
+    # Acciones
+    def on_crear(self):
+        if self.structure is not None:
+            if not mb.askyesno("Confirmar", "Esto borrará la estructura actual. ¿Continuar?"):
+                return
+        try:
+            exp = int(self.var_exp.get())
+            klen = int(self.var_klen.get())
+        except ValueError:
+            self._error("Parámetros inválidos")
+            return
+        try:
+            self.structure = self.structure_cls(10 ** exp, klen)  # type: ignore[call-arg]
+        except Exception as e:
+            self._error(str(e))
+            return
+        self._set_estado("Estructura creada.")
+        self._set_config_enabled(False)
+        self._set_controls_enabled(True)
+        self._update_counters()
+        self._refresh_view()
+
+    def on_borrar(self):
+        if self.structure is None:
+            return
+        if not mb.askyesno("Confirmar", "Se borrará la estructura actual. ¿Continuar?"):
+            return
+        self.structure = None
+        self._set_config_enabled(True)
+        self._set_controls_enabled(False)
+        self._update_counters()
+        self._refresh_view()
+        self._set_estado("Estructura borrada. Configura y pulsa Crear.")
+
+    def on_insertar(self):
+        ok, val, err = self._parse_key()
+        if not ok:
+            self._error(err or "")
+            return
+        try:
+            idx = self.structure.insert(val)  # type: ignore[union-attr]
+        except Exception as e:
+            self._error(str(e))
+            return
+        block, offset = self.structure.locate_index(idx)  # type: ignore[union-attr]
+        self._set_estado(f"Insertado {val} en bloque B{block + 1}, posición {offset + 1}.")
+        self._update_counters()
+        self._refresh_view(HighlightState(block=block, offset=offset, found=True))
+
+    def on_buscar(self):
+        ok, val, err = self._parse_key()
+        if not ok:
+            self._error(err or "")
+            return
+        result = self.structure.find(val)  # type: ignore[union-attr]
+        if result.found:
+            self._set_estado(
+                f"Búsqueda {self.search_kind_label}: {val} encontrado en bloque B{result.block + 1}, posición {result.offset + 1}."
+            )
+            self._refresh_view(
+                HighlightState(
+                    block=result.block,
+                    offset=result.offset,
+                    found=True,
+                    highlight_base=True,
+                )
+            )
+        else:
+            if result.block >= 0:
+                self._set_estado(
+                    f"Búsqueda {self.search_kind_label}: {val} no encontrado. Revisado hasta bloque B{result.block + 1}."
+                )
+                self._refresh_view(
+                    HighlightState(
+                        block=result.block,
+                        offset=None,
+                        found=False,
+                        highlight_base=True,
+                    )
+                )
+            else:
+                self._set_estado(
+                    f"Búsqueda {self.search_kind_label}: {val} no encontrado."
+                )
+                self._refresh_view()
+
+    def on_eliminar(self):
+        ok, val, err = self._parse_key()
+        if not ok:
+            self._error(err or "")
+            return
+        try:
+            idx = self.structure.delete(val)  # type: ignore[union-attr]
+        except Exception as e:
+            self._error(str(e))
+            return
+        self._set_estado(f"Eliminado {val} desde índice {idx}.")
+        self._update_counters()
+        self._refresh_view()
+
+    def on_guardar(self):
+        if not self.structure:
+            self._error("No hay estructura creada para guardar.")
+            return
+        path = fd.asksaveasfilename(
+            title="Guardar estructura",
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json")],
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(self.structure.to_json())
+            self._set_estado(f"Guardado en {path}.")
+        except Exception as e:
+            self._error(f"Error al guardar: {e}")
+
+    def on_cargar(self):
+        path = fd.askopenfilename(
+            title="Cargar estructura",
+            filetypes=[("JSON", "*.json")],
+        )
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data: Dict[str, object] = json.load(f)
+            struct = self.structure_cls.from_dict(data)  # type: ignore[arg-type]
+        except Exception as e:
+            self._error(f"Error al cargar: {e}")
+            return
+        self.structure = struct
+        exp = int(round(math.log10(self.structure.capacity)))
+        self.var_exp.set(str(exp))
+        self.var_klen.set(str(self.structure.key_length))
+        self._set_config_enabled(False)
+        self._set_controls_enabled(True)
+        self._update_counters()
+        self._set_estado(f"Estructura cargada desde {path}.")
+        self._refresh_view()
+
+    def on_generar(self):
+        if not self.structure:
+            self._error("Primero crea o carga la estructura.")
+            return
+        try:
+            count = int((self.var_gen_count.get() or "0").strip())
+        except ValueError:
+            self._error("Cantidad inválida.")
+            return
+        if count <= 0:
+            self._error("La cantidad debe ser mayor que 0.")
+            return
+        added = self.structure.generate_random(count)  # type: ignore[union-attr]
+        self._set_estado(f"Generados {added} elementos aleatorios.")
+        self._update_counters()
+        self._refresh_view()

--- a/views/external_binary.py
+++ b/views/external_binary.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .external_base import ExternalBaseContent
+from models.external import ExternalBinaryStructure
+
+
+class ExternalBinaryContent(ExternalBaseContent):
+    title = "B. Externas · Búsqueda Binaria"
+    structure_cls = ExternalBinaryStructure
+    search_button_text = "Buscar (bin.)"
+    search_kind_label = "binaria"

--- a/views/external_sequential.py
+++ b/views/external_sequential.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .external_base import ExternalBaseContent
+from models.external import ExternalSequentialStructure
+
+
+class ExternalSequentialContent(ExternalBaseContent):
+    title = "B. Externas · Búsqueda Secuencial"
+    structure_cls = ExternalSequentialStructure
+    search_button_text = "Buscar (sec.)"
+    search_kind_label = "secuencial"


### PR DESCRIPTION
## Summary
- add data models for external sequential and binary searches with block-based utilities
- create shared external search view with block visualisation plus specialised sequential/binaria screens
- expose the new external search sections in the navigation sidebar and content router

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0a4a1ffb0832da31e1dd7a08eb199